### PR TITLE
Correct use of encoding in test_os_jy test of getcwd. Fixes #2646.

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -1370,7 +1370,7 @@ _failures = {
     'java.nt':     # Expected to fail on Windows
         """
         test_mailbox           # fails miserably and ruins other tests
-        test_os_jy             # Locale tests fail on Cygwin (but not Windows)
+        # test_os_jy             # Locale tests fail on Cygwin (but not Windows)
         # test_popen             # Passes, but see http://bugs.python.org/issue1559298
         test_select_new        # Hangs (Windows), though ok run singly
         test_urllib2           # file not on local host (likely Windows only)


### PR DESCRIPTION
All information is in the FS encoding, so decode() was spurious, and
only passed because of a false conception of == between str and unicode,
corrected in #2630. We re-enable the test for Windows, as it keeps
catching us out, add a similar test for getcwdu, and beef up comments.